### PR TITLE
Readonly modifiers is a good practice to avoid unintended copies

### DIFF
--- a/Unity/Assets/JCMG/Curves/Scripts/Core/Knot.cs
+++ b/Unity/Assets/JCMG/Curves/Scripts/Core/Knot.cs
@@ -11,12 +11,12 @@ namespace JCMG.Curves
 		/// <summary>
 		/// Returns true if a custom rotation has been specified, otherwise false.
 		/// </summary>
-		public bool IsUsingRotation => rotation != null;
+		public readonly bool IsUsingRotation => rotation != null;
 
 		/// <summary>
 		/// Returns true if a handles are auto-adjusted, otherwise false.
 		/// </summary>
-		public bool IsUsingAutoHandles => Math.Abs(auto) > .00001f;
+		public readonly bool IsUsingAutoHandles => Math.Abs(auto) > .00001f;
 
 		/// <summary>
 		/// Position of the knot local to spline.

--- a/Unity/Assets/JCMG/Curves/Scripts/Core/NullableQuaternion.cs
+++ b/Unity/Assets/JCMG/Curves/Scripts/Core/NullableQuaternion.cs
@@ -12,7 +12,7 @@ namespace JCMG.Curves
 		/// <summary>
 		/// Returns the <see cref="Quaternion"/> value.
 		/// </summary>
-		public Quaternion Value
+		public readonly Quaternion Value
 		{
 			get { return rotation; }
 		}
@@ -20,7 +20,7 @@ namespace JCMG.Curves
 		/// <summary>
 		/// Returns the <see cref="Quaternion"/> value if present, otherwise null.
 		/// </summary>
-		public Quaternion? NullableValue
+		public readonly Quaternion? NullableValue
 		{
 			get { return hasValue ? (Quaternion?)rotation : null; }
 		}
@@ -28,7 +28,7 @@ namespace JCMG.Curves
 		/// <summary>
 		/// Returns true if a <see cref="Quaternion"/> value is present, otherwise false.
 		/// </summary>
-		public bool HasValue
+		public readonly bool HasValue
 		{
 			get { return hasValue; }
 		}


### PR DESCRIPTION
Using readonly modifiers in struct properties and methods can help to avoid unintended copies. [Link to docs](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/struct#readonly-instance-members).
This will only work for Unity with C# 8.0 support (Unity 2020+ if I'm not mistaken), so if you plan to support older versions, may not want to merge.